### PR TITLE
fix shebang line

### DIFF
--- a/after.py
+++ b/after.py
@@ -1,5 +1,5 @@
- #!/usr/bin/env python
- 
+#!/usr/bin/env python
+
 import os,sys
 from optparse import OptionParser
 import time


### PR DESCRIPTION
Hi,

please remove the first space before the first-line `#` in after.py, it is causing this error (the file interpreter is not recognized):

```
$ ./after.py
from: can't read /var/mail/optparse
from: can't read /var/mail/multiprocessing
from: can't read /var/mail/util
./after.py: line 12: syntax error near unexpected token `('
./after.py: line 12: `def parseCommand():
```

Thanks :)
